### PR TITLE
Adds reliability and simplifies, finalizes v1 HTTP API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,17 @@
 // External
 var express = require('express');
+var responseCodes = require('http-response-codes')
 var tar = require('tar-fs')
 var temp = require('temp');
+var toml = require('toml');
 var debug = require('debug')('server');
+var base64 = require('base64-stream');
 
 // System
 var exec = require('child_process').exec;
 var path = require('path');
 var fs = require('fs');
+var stream = require('stream');
 
 // Initialize Express
 var app = express();
@@ -18,59 +22,127 @@ var tmpPrefix = "tessel-rust-compile"
 // Automatically track and cleanup files at exit
 temp.track();
 
-app.get('/', (req, res) => {
-  res.send('Tessel Rust Cross Compilation Server!');
-})
-
 // Accept post requests to this route
 app.post('/rust-compile', function(req, res) {
-    var projectName = req.headers['x-project-folder'];
-    var binaryName = req.headers['x-binary-name'];
-    debug('Received a request for project:', projectName);
-    if (!projectName) {
-        res.statusCode(400, "Project name header not provided");
-        return;
+
+  function rejectRequest(statusCode, errorString) {
+    res.status(statusCode).send(JSON.stringify({error: errorString}));
+  }
+
+  // Make note that we are starting a ccx process
+  debug('Received a request for project.');
+
+  // Create a temporary directory for the incoming project
+  temp.mkdir(tmpPrefix, function(mkdirError, dirPath) {
+
+    // If there was an error creating a temporary directory
+    if (mkdirError !== null) {
+      // Abort the request and notify the client
+      return rejectRequest(responseCodes.HTTP_INTERNAL_SERVER_ERROR, mkdirError);
     }
 
-    // Create a temporary directory for the incoming project
-    temp.mkdir(tmpPrefix, function(err, dirPath) {
-      debug("Saving", projectName, 'to', dirPath, 'with binary name', binaryName);
-      // unzip and extract the binary tarball
-      req.pipe(tar.extract(dirPath))
-      // Once that process completes
-      .on('finish', function extractionComplete() {
-          var projectPath = path.join(dirPath, projectName);
-          // Create a child process that will compile the project
-          var child = exec('cargo build --target=tessel2 --release',
-          {
-              // Work out of the directory of the created folder
-              cwd: projectPath,
-          },
-          function (error, stdout, stderr) {
-            debug(`output of compilation - error: ${error}, stdout: ${stdout}, stderr: ${stderr}`)
-              // If we had stderr output (like compilation failure)
-              if (error !== null) {
-                  // Report the error
-                  res.status(400).send(error);
-              }
-              // No error on compilation
-              else {
-                  // Figure out the path to the binary
-                  var binaryPath = path.join(projectPath, 'target/tessel2/release/');
-                  // Send the status flag
-                  res.status(200);
-                  // Pack up the compiled binary and send it back down
-                  // TODO: Make the binary the only file in the folder
-                  var stream = tar.pack(binaryPath).pipe(res);
-                  // When we finish writing the file to the CLI, delete the temp folder
-                  stream.once('finish', () => {
-                    debug('Finished cross compilation job.');
-                    temp.cleanupSync();
-                  });
-              }
+    // Create a stream for extracting the uploaded project archive
+    var extractStream = tar.extract(dirPath);
+    // Send the incoming project tarball into the extractor
+    req.pipe(extractStream);
+    // Once the extraction completes
+    extractStream.once('finish', function extractionComplete() {
+      // Read the contents of the extracted directory:
+      // -- temp_dir
+      // ---- deployed_project_filder
+      fs.readdir(dirPath, (readDirError, contents) => {
+
+        // If we were unable to read the directory
+        if (readDirError !== null) {
+          // Let the client know that we had an issue
+          return rejectRequest(responseCodes.HTTP_INTERNAL_SERVER_ERROR, readDirError);
+        }
+
+        // There should only be a single folder (the deployed folder)
+        if (contents.length !== 1) {
+          // If there zero or more than one, reject and notify client
+          return rejectRequest(responseCodes.HTTP_BAD_REQUEST,
+            'Too many project directories deployed.');
+        }
+
+        // Save the name of the deployed project folder
+        projectName = contents.shift();
+        debug("Project name:", projectName);
+        // Save the path to this project
+        var projectPath = path.join(dirPath, projectName);
+        // Save a path to where the compiled binary will be
+        var binaryPath = path.join(projectPath, 'target/tessel2/release/');
+
+        // Read the contents of the Cargo.toml to extract binary name
+        // Print out the binary name
+        try {
+          var cargoToml = toml.parse(fs.readFileSync(path.join(projectPath, 'Cargo.toml'), 'utf8'));
+        }
+        catch (error) {
+          debug("Problem parsing Cargo.toml :", error);
+          return rejectRequest(responseCodes.HTTP_BAD_REQUEST, error);
+        }
+
+        // Ensure the Cargo.toml has a package field and a name property
+        if (cargoToml.package === undefined || cargoToml.package.name === undefined) {
+          return rejectResponse(responseCodes.HTTP_BAD_REQUEST, 'No package name found in Cargo.toml');
+        }
+
+        // Save the name of the final binary so we can exclude all other files
+        var binaryName = cargoToml.package.name;
+
+        // Create a child process that will compile the project
+        var child = exec('cargo build --target=tessel2 --release',
+        {
+          // Work out of the directory of the created folder
+          cwd: projectPath,
+        },
+        function (error, stdout, stderr) {
+          debug(`output of compilation - error: ${error}, stdout: ${stdout}, stderr: ${stderr}`)
+
+          // If we had an error with the command
+          if (error !== null) {
+            // Report the error
+            return rejectRequest(responseCodes.HTTP_INTERNAL_SERVER_ERROR, error.message);
+          }
+          // Send the status flag
+          res.status(responseCodes.HTTP_OK);
+
+          /*
+           Write all the parts of the results JSON except the binary.
+           We do this instead of writing with JSON.stringify because
+           we'll want to stream the binary tarball into the JSON
+           response as it's packed instead of waiting for the entire
+           buffer to load into RAM.
+           */
+          res.write(`{`);
+          res.write(`"stdout":${JSON.stringify(stdout)}`);
+          res.write(`,`);
+          res.write(`"stderr":${JSON.stringify(stderr)}`);
+          res.write(`,`);
+          res.write(`"binary": "`);
+
+          // Create a stream that starts packing only the compiled binary
+          // Base-64 encode it because we're loading it into JSON (strings)
+          var packingStream = tar.pack(binaryPath, {entries : [binaryName]})
+            .pipe(base64.encode());
+
+          // Pipe the archived binary into the result but do not end response pipe
+          // when the tarball packing completes
+          packingStream.pipe(res, { end: false });
+          // When the binary has been written,
+          packingStream.once('end', () => {
+            // Write the ending quote and bracket for the JSON
+            res.end(`"}`);
+            // Make a note for our logs
+            debug('Finished cross compilation job.');
+            // Delete the temporary directory
+            temp.cleanupSync();
           });
-      });
+        });
+      })
     });
+  });
 });
 
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
-  "author": "",
+  "author": "Jon McKay <jon@tessel.io>",
   "name": "rust-compilation-server",
-  "description": "A server designed to build Rust pprojects for Tessel2",
-  "version": "0.0.0",
+  "description": "A server designed to build Rust projects for Tessel 2",
+  "version": "1.0.0",
   "repository": {
     "url": ""
   },
   "dependencies": {
+    "base64-stream": "^0.1.3",
     "debug": "^2.2.0",
     "express": "^4.13.3",
+    "http-response-codes": "^1.0.4",
     "tar-fs": "^1.9.0",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "toml": "^2.3.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
Previously, the HTTP API required headers to indicate the name of the compiled binary and the name of the project folder. This PR removes those headers and instead deduces the name of the project after unpacking it and grabs the binary name from the Cargo.toml.

Additionally, this PR adds JSON support to the response which not only makes the error handling easier for the client but allows the server to send down compilation logs.

This server should be all set for 1.0.0 release.
