### PR TITLE
Compile with Rust 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,17 @@ RUN tar xf OpenWrt-SDK-ramips-mt7620_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64
 ENV STAGING_DIR /usr/x-compile/OpenWrt-SDK-ramips-mt7620_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64/staging_dir
 ENV PATH $STAGING_DIR/toolchain-mipsel_24kec+dsp_gcc-4.8-linaro_uClibc-0.9.33.2/bin/:$PATH
 
-# Pull down Rust source @ 1.5.0
-RUN git clone https://github.com/rust-lang/rust; cd rust; git checkout tags/1.5.0
+# Pull down Rust source @ 1.10.0
+RUN git clone https://github.com/rust-lang/rust; cd rust; git checkout tags/1.10.0
 # Pull down and extract the Rust installer
-RUN wget https://static.rust-lang.org/dist/rust-1.5.0-x86_64-unknown-linux-gnu.tar.gz
-RUN tar xf rust-1.5.0-x86_64-unknown-linux-gnu.tar.gz
+RUN wget https://static.rust-lang.org/dist/rust-1.10.0-x86_64-unknown-linux-gnu.tar.gz
+RUN tar xf rust-1.10.0-x86_64-unknown-linux-gnu.tar.gz
 # Install the cloned version of Rust
-RUN rust-1.5.0-x86_64-unknown-linux-gnu/install.sh --prefix=$PWD/rust-root
+RUN rust-1.10.0-x86_64-unknown-linux-gnu/install.sh --prefix=$PWD/rust-root
 
 # Pull down @kevinmehall's cross compilation script and a device config for Tessel 2
-RUN wget https://gist.githubusercontent.com/kevinmehall/16e8b3ea7266b048369d/raw/87e6885967c59368f4a53b5ab1122f24db84ba70/rust-cross-libs.sh && chmod +x rust-cross-libs.sh
-RUN wget https://gist.githubusercontent.com/kevinmehall/16e8b3ea7266b048369d/raw/87e6885967c59368f4a53b5ab1122f24db84ba70/tessel2.json
+RUN wget https://gist.githubusercontent.com/kevinmehall/16e8b3ea7266b048369d/raw/003379cea82040eb0122606bf9dca02fa59f981f/rust-cross-libs.sh && chmod +x rust-cross-libs.sh
+RUN wget https://gist.githubusercontent.com/kevinmehall/16e8b3ea7266b048369d/raw/003379cea82040eb0122606bf9dca02fa59f981f/tessel2.json
 
 # Cross compile the standard libraries for Tessel 2
 RUN ./rust-cross-libs.sh --rust-prefix=$PWD/rust-root --rust-git=rust --target-json=tessel2.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jon McKay <jon@tessel.io>",
   "name": "rust-compilation-server",
   "description": "A server designed to build Rust projects for Tessel 2",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "url": ""
   },


### PR DESCRIPTION
Updates Gist references to use @kevinmehall's work on targeting Rust 1.10.0 instead of 1.5.0 which allows newer projects to be compiled. 
