### PR TITLE
Streamlines Docker setup and README instructions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,28 +16,16 @@ RUN tar xf OpenWrt-SDK-ramips-mt7620_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64
 ENV STAGING_DIR /usr/x-compile/OpenWrt-SDK-ramips-mt7620_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64/staging_dir
 ENV PATH $STAGING_DIR/toolchain-mipsel_24kec+dsp_gcc-4.8-linaro_uClibc-0.9.33.2/bin/:$PATH
 
-# Pull down Rust source @ 1.10.0
-RUN git clone https://github.com/rust-lang/rust; cd rust; git checkout tags/1.10.0
-# Pull down and extract the Rust installer
-RUN wget https://static.rust-lang.org/dist/rust-1.10.0-x86_64-unknown-linux-gnu.tar.gz
-RUN tar xf rust-1.10.0-x86_64-unknown-linux-gnu.tar.gz
-# Install the cloned version of Rust
-RUN rust-1.10.0-x86_64-unknown-linux-gnu/install.sh --prefix=$PWD/rust-root
-
-# Pull down @kevinmehall's cross compilation script and a device config for Tessel 2
-RUN wget https://gist.githubusercontent.com/kevinmehall/16e8b3ea7266b048369d/raw/003379cea82040eb0122606bf9dca02fa59f981f/rust-cross-libs.sh && chmod +x rust-cross-libs.sh
-RUN wget https://gist.githubusercontent.com/kevinmehall/16e8b3ea7266b048369d/raw/003379cea82040eb0122606bf9dca02fa59f981f/tessel2.json
-
-# Cross compile the standard libraries for Tessel 2
-RUN ./rust-cross-libs.sh --rust-prefix=$PWD/rust-root --rust-git=rust --target-json=tessel2.json
-
 # Docker requires us to set a user for whatever reason (cargo will throw error otherwise)
 ENV USER tesselator
 
-# Set our PATH so we can use Rust binaries and our newly compiled standard lib
-ENV PATH /usr/x-compile/rust-root/bin:$PATH
-ENV LD_LIBRARY_PATH /usr/x-compile/rust-root/lib
-ENV RUST_TARGET_PATH /usr/x-compile
+# Install rustup, then stable.
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH /root/.cargo/bin:$PATH
+RUN rustup install nightly-2016-09-08
+RUN rustup default nightly-2016-09-08
+RUN rustup target add mipsel-unknown-linux-gnu
+COPY cargo_config /root/.cargo/config
 
 # Install Node.js
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash - && sudo apt-get install -y nodejs

--- a/README.md
+++ b/README.md
@@ -1,82 +1,88 @@
 # rust-compilation-server
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/tessel/project/blob/master/CONDUCT.md)
 
-A server to run on an Linux box with Rust MIPS Cross Compilation capabilities. 
+A server to run on an Linux box with Rust MIPS Cross Compilation capabilities.
 
 ## Dependencies
-* [Docker](https://www.docker.com/) for containerization
+
+* [Docker](https://www.docker.com/products/docker) for containerization. Please install the new "Docker for Mac", "Docker for Windows", or "Docker for Linux" apps to follow the instructions below.
 
 ## Install
-* Either clone this source or pull the docker image (`docker pull johnnyman727/rust-compilation-server`)
-* Build and run the server with `docker run -p 49160:8080 -d johnnyman727/rust-compilation-server`. On OSX, the ip address will be the IP Address of your VM (`docker-machine ip`) but on other systems, it will be `localhost`. The port is exposed as 49160.
 
-## Usage
-You will need to make a POST request to the `/rust-compile` path on port 49160 of the appropriate IP. You will also need to set three headers: `Content-Type` should be `application/octet stream`, `X-BINARY-NAME` should be the name of the program (we should eventually parse this out of the Cargo.toml), and `X-PROJECT-FOLDER` should be the name of the root directory of the project (we can also probably get rid of this pretty easily).
+Local development:
+
+* Clone this repository.
+* Run `docker build . -t rustcc`.
+* Run `docker run -p 49160:8080 -d rustcc`.
+
+Or, to install from source through Docker:
+
+* Either clone this source or pull the docker image (`docker pull johnnyman727/rust-compilation-server`)
+* Build and run the server with `docker run -p 49160:8080 -d johnnyman727/rust-compilation-server`.
+
+The server will be bound to `localhost:49160`. Once the server is running:
+
+* [Clone](https://github.com/tessel/t2-cli) or install the command line interface: `npm install t2-cli -g`
+* Make a new directory and inside, create a new Rust project with `t2 init --lang=rust` (it contains a blinky example)
+* Deploy the project with `t2 run Cargo.toml --rustcc=localhost:49160`
+
+To make changes to the server, open two shells. In the first, get access to the shell of the Docker server with `docker attach DOCKER_ID` (you can get your `DOCKER_ID` from `docker ps`. Make changes to `index.js` and then run `docker cp index.js DOCKER_ID:/usr/src/app`. If you make changes to the Dockerfile, run `docker build . -t rustcc`.
+
+## Server API
+
+You will need to make a POST request to the `/rust-compile` path on port 49160 of the appropriate IP. You will also need to set three headers: `Content-Type` should be `application/octet-stream`, `X-BINARY-NAME` should be the name of the program (we should eventually parse this out of the Cargo.toml), and `X-PROJECT-FOLDER` should be the name of the root directory of the project (we can also probably get rid of this pretty easily).
 
 An example of usage is below
 
-```.js
-    return new Promise(function(resolve, reject) {
+```js
+return new Promise(function(resolve, reject) {
+  var buffers = [];
 
-        var buffers = [];
+  var post_options = {
+    host: '192.168.99.100',
+    port: '49160',
+    path: '/rust-compile',
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/octet-stream',
+        'X-BINARY-NAME': project.program,
+        'X-PROJECT-FOLDER': path.basename(project.pushdir),
+    }
+  };
 
-        var post_options = {
-          host: '192.168.99.100',
-          port: '49160',
-          path: '/rust-compile',
-          method: 'POST',
-          headers: {
-              'Content-Type': 'application/octet-stream',
-              'X-BINARY-NAME': project.program,
-              'X-PROJECT-FOLDER': path.basename(project.pushdir),
-          }
-        };
+  // Set up the request
+  var post_req = http.request(post_options, function(res) {
+    var f = reject;
+    if (res.statusCode === 200) {
+      f = resolve;
+    }
 
-        // Set up the request
-        var post_req = http.request(post_options, function(res) {
-          var f = reject;
-          if (res.statusCode === 200) {
-            f = resolve;
-          }
+    res.on('data', function(chunk) {
+        buffers.push(chunk);
+    })
+    .on('error', function(e) {
+        return reject(e);
+    })
+    .on('end', function() {
+        f(Buffer.concat(buffers));
+    })
+  });
 
-          res.on('data', function(chunk) {
-              buffers.push(chunk);
-          })
-          .on('error', function(e) {
-              return reject(e);
-          })
-          .on('end', function() {
-              f(Buffer.concat(buffers));
-          })
-        });
+  var outgoingPacker = tar.Pack({ noProprietary: true })
+    .on('error', reject)
 
-        var outgoingPacker = tar.Pack({ noProprietary: true })
-          .on('error', reject)
-
-          // This must be a "directory"
-        Reader({ path: project.pushdir, type: "Directory" })
-          .on('error', reject)
-          .pipe(outgoingPacker)
-          .pipe(post_req)
-    });
+    // This must be a "directory"
+  Reader({ path: project.pushdir, type: "Directory" })
+    .on('error', reject)
+    .pipe(outgoingPacker)
+    .pipe(post_req)
+});
 ```
 
 The server sends back error code 400 is the compilation fails for whatever reason and writes out the error in the response. If the compilation succeeds, it sends back error code 200 along with the executable.
 
 ## Rationale
 
-We got started on building a cross-compilation server several months ago. @kevinmehall did a bunch of work to figure out exactly how to build a Rust binary for the MIPS architecture and that work has been automated into [this Docker script](https://github.com/tessel/rust-compilation-server/blob/master/Dockerfile).
-The [cross compilation server](https://github.com/tessel/rust-compilation-server) includes that Dockerfile as well as Node server that presents an single API endpoint for cross-compilation. It receives a POST request that sends a tarred project directory, cross compiles that project, then sends the tarred binary back down to the client.  The server is awaiting [v1.0 to land](https://github.com/tessel/rust-compilation-server/pull/6).
-To run it, clone this directory and checkout the `jon-1.0.0` branch, build the Docker image (requires Docker to be installed) with `docker build . -t rustCC`, then run it with `docker run -p 49160:8080 rustCC`.
+The [cross compilation server](https://github.com/tessel/rust-compilation-server) describes a Docker instance as well as Node server that presents an single API endpoint for cross-compilation for Rust. It receives a POST request that sends a tarred project directory, cross compiles that project, then sends the tarred binary back down to the client.
 
-The cross compilation server is a critical tool for helping new Rust users get started quickly without installing external dependencies. However, we want to encourage users to use [`rustup`](http://blog.rust-lang.org/2016/05/13/rustup.html) locally for more mature Tessel projects. Until we have a path forward for Windows users and infrastructure for building against the Tessel SDK easy, we will be maintaining both implementations to provide the best experiences possible.
-
-## Developing on the Remote Cross Compilation Server (`Docker`, `git` and `Node` 4.x are requirements)
-
-* Clone the [cross-compilation server repo](https://github.com/tessel/rust-compilation-server) and checkout the `jon-1.0.0` branch.
-* Build the Docker image with `docker build -t rustcc .`, then run it with `docker run -p 49160:8080 rustcc`.
-* [Clone](https://github.com/tessel/t2-cli) or install the command line interface: `npm install t2-cli -g`
-* Make a new directory and inside, create a new Rust project with `t2 init --lang=rust` (it contains a blinky example)
-* Deploy the project with `t2 run Cargo.toml --rustcc=$(docker-machine ip):49160`
-* To make changes to the server, open two shell. In the first, get access to the shell of the Docker server with `docker attach DOCKER_ID` (you can get your `DOCKER_ID` from `docker ps`. Make changes to `index.js` and then run `docker cp index.js DOCKER_ID:/usr/src/app`. If you make changes to the Dockerfile, run `docker build .`.
-
+The cross compilation server is a critical tool for helping new Rust users get started quickly without installing external dependencies. However, we want to encourage users to use [`rustup`](http://blog.rust-lang.org/2016/05/13/rustup.html) locally for more mature Tessel projects. Until we have a path forward for Windows users and infrastructure for building against the Tessel SDK easily, we will be maintaining both implementations to provide the best experiences possible.

--- a/cargo_config
+++ b/cargo_config
@@ -1,0 +1,5 @@
+[target.mipsel-unknown-linux-gnu]
+linker = "mipsel-openwrt-linux-gcc"
+
+[build]
+target = "mipsel-unknown-linux-gnu"

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ app.post('/rust-compile', function(req, res) {
         // Save the path to this project
         var projectPath = path.join(dirPath, projectName);
         // Save a path to where the compiled binary will be
-        var binaryPath = path.join(projectPath, 'target/tessel2/release/');
+        var binaryPath = path.join(projectPath, 'target/mipsel-unknown-linux-gnu/release/');
 
         // Read the contents of the Cargo.toml to extract binary name
         // Print out the binary name
@@ -92,7 +92,7 @@ app.post('/rust-compile', function(req, res) {
         var binaryName = cargoToml.package.name;
 
         // Create a child process that will compile the project
-        var child = exec('cargo build --target=tessel2 --release',
+        var child = exec('cargo build --target=mipsel-unknown-linux-gnu --release',
         {
           // Work out of the directory of the created folder
           cwd: projectPath,
@@ -145,6 +145,9 @@ app.post('/rust-compile', function(req, res) {
   });
 });
 
+app.get('/', function (req, res) {
+  res.end('Tessel 2 Rust cross-compilation server.');
+})
 
 app.listen(process.env.PORT || 8080);
 


### PR DESCRIPTION
- Cleans up Dockerfile to use Rustup + SDK + MIPS target, much like the rust-tessel instructions.
- Bumps Rust nightly to 2016-09-08, arbitrary date post Rust 1.11.
- Cleans up README to remove old content.
- Updates README to reflect OS X development using the new Docker for Mac, which allows localhost ports to be exposed just like they are on Linux (thus, simpler).

Tested and verified to work locally.
